### PR TITLE
buildDockerImage.sh for cross build on WSL

### DIFF
--- a/mcp_server/src/scripts/buildDockerImage.sh
+++ b/mcp_server/src/scripts/buildDockerImage.sh
@@ -75,7 +75,7 @@ else
 fi
 
 if [ "$CONTAINER_TOOL" = "docker" ]; then
-  docker build --platform linux/arm64 $NETWORK_OPTION -t $LOCAL_TAG .
+  docker buildx build --platform linux/arm64 $NETWORK_OPTION -t $LOCAL_TAG --load .
   
   # Tag with ECR URI if specified
   if [ -n "$ECR_REPO_URI" ]; then


### PR DESCRIPTION
On WSL building for arm64 cannot be performed without using docker buildx.

*Issue #, if available:*

*Description of changes:*

- updated `mcp_server/src/scripts/buildDockerImage.sh` docker build command line to use buildx


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
