### PR TITLE
Fix for tokens not refreshing correctly

### DIFF
--- a/mcp_client/src/hooks/useMcpConnection.ts
+++ b/mcp_client/src/hooks/useMcpConnection.ts
@@ -338,20 +338,13 @@ export function useMcpConnection({
         clientSecret
       );
       
-      // Use manually provided bearer token if available, otherwise use OAuth tokens - exactly like Inspector
-      let token: string | undefined;
+      // Use manually provided bearer token if available, otherwise use OAuth tokens
       if (bearerToken) {
         // Manual bearer token provided - use it directly, skip OAuth
-        token = bearerToken;
+        let token = bearerToken;
         console.log("🔍 Token Debug:");
         console.log("  Using manual bearer token");
         console.log("  Token length:", token.length);
-      } else {
-        // No manual token - try OAuth
-        token = (await serverAuthProvider.tokens())?.access_token;
-      }
-      
-      if (token) {
         const authHeaderName = headerName || "Authorization";
         if (authHeaderName.toLowerCase() !== "authorization") {
           headers[authHeaderName] = token;
@@ -360,6 +353,9 @@ export function useMcpConnection({
           headers[authHeaderName] = `Bearer ${token}`;
         }
       }
+      // For OAuth: DO NOT add Authorization header to requestInit.headers
+      // The authProvider will handle adding fresh tokens automatically
+      // If we add tokens to requestInit.headers, they will override the authProvider's fresh tokens!
 
       // Create transport using our proxy - environment-aware URL
       const transportOptions: StreamableHTTPClientTransportOptions = {


### PR DESCRIPTION
*Issue #, if available:*

No formal issue logged, but I found what I believe to be a bug with OAuth token refresh while working on some other code.  My test process:
 * Auth to the MCP
 * Send a request & verify that it worked
 * Wait >5 mins so that the original token expires
 * Send another request and observe that it fails due to invalid credentials


*Description of changes:*

OAuth tokens were not refreshing correctly when using the MCP client. The issue was caused by manually adding OAuth access tokens to the request headers, which prevented the authProvider from managing token lifecycle and automatic refresh.

The fix separates the handling of manual bearer tokens from OAuth tokens:

 * **Manual Bearer Tokens**: Continue to add directly to headers (as intended for static tokens)
 * **OAuth Tokens**: Let the authProvider handle token management entirely by NOT adding them to requestInit.headers

The StreamableHTTPClientTransport with an authProvider automatically:

 * Adds fresh tokens to each request
 * Detects expired tokens
 * Refreshes tokens when needed
 * Retries failed requests with new tokens

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
