### PR TITLE
fix: include tools/resources js in dist, advertise public-client OAuth metadata

### DIFF
--- a/mcp_server/infra/lambda/openid-config/openid-config.mjs
+++ b/mcp_server/infra/lambda/openid-config/openid-config.mjs
@@ -105,6 +105,14 @@ async function getOpenIDConfiguration() {
     const enhancedConfig = {
       ...cognitoConfig,
       registration_endpoint: registrationEndpointUrl,
+      grant_types_supported: [
+        ...(cognitoConfig.grant_types_supported || []),
+        "authorization_code"
+      ],
+      token_endpoint_auth_methods_supported: [
+        ...(cognitoConfig.token_endpoint_auth_methods_supported || []),
+        "none"
+      ],
       code_challenge_methods_supported: ["S256"]
     };
 

--- a/mcp_server/src/package.json
+++ b/mcp_server/src/package.json
@@ -21,7 +21,7 @@
     "typescript": "^5.8.3"
   },
   "scripts": {
-    "build": "tsc && cp *.js *.json dist/ && cp -r prompts mcp auth dist/",
+    "build": "tsc && cp *.js *.json dist/ && cp -r prompts mcp auth dist/ && mkdir -p dist/tools dist/resources && cp tools/*.js dist/tools/ && cp resources/*.js dist/resources/",
     "start": "npx tsx --env-file=.env --watch index.js",
     "start:prod": "node dist/index.js",
     "test": "vitest run",


### PR DESCRIPTION
Two server-side fixes found while debugging a stuck deploy.

**Build fix.** `npm run build` copies `prompts/`, `mcp/`, `auth/` into `dist/` but not `tools/` or `resources/`. `tsc` handles the `.ts` files in those dirs, but `tools/register.js` and `resources/register.js` are plain JS — so they never make it into the image. Container crashed on startup with `ERR_MODULE_NOT_FOUND`, and CFN reported it as a generic `AWS::ECS::ExpressGatewayService` error that was hard to trace back to a missing file.

**OIDC discovery fix.** Cognito's `/.well-known/openid-configuration` doesn't advertise `authorization_code` or `none` as a token endpoint auth method. MCP clients register via DCR as public clients (no secret, PKCE), so they need both to pick the right flow. The deployed Lambda already returns these — this just gets the source in sync so a fresh `cdk deploy` doesn't regress.

Tested: `npm test` green, full redeploy works, `/health`, OAuth metadata, and `/mcp` 401 challenge all look right.