### PR TITLE
ci: docker-smoke-test + merge_group trigger (bundled with #58 fixes)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,67 @@ jobs:
           cache-dependency-path: mcp_server/infra/package-lock.json
       - run: npm ci
       - run: npx cdk synth --quiet
+
+  docker-smoke-test:
+    runs-on: ubuntu-latest
+    needs: mcp-server-tests
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: mcp_server/src/package-lock.json
+
+      - name: Install dependencies
+        working-directory: mcp_server/src
+        run: npm ci
+
+      - name: Build application
+        working-directory: mcp_server/src
+        run: npm run build
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (load locally, no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: mcp_server/src
+          platforms: linux/amd64
+          load: true
+          tags: mcp-server:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Boot container and probe /health
+        run: |
+          docker run -d --name mcp-test -p 3000:3000 \
+            -e TABLE_NAME=ci-dummy \
+            -e ROLE_ARN=arn:aws:iam::000000000000:role/ci \
+            -e BUCKET_NAME=ci-dummy \
+            -e COGNITO_USER_POOL_ID=us-east-1_CI \
+            -e COGNITO_DOMAIN=ci \
+            -e AWS_REGION=us-east-1 \
+            mcp-server:ci
+
+          for i in {1..15}; do
+            if curl -fsS http://localhost:3000/health; then
+              echo ""
+              echo "✅ /health responded"
+              docker logs mcp-test
+              exit 0
+            fi
+            echo "attempt $i: /health not ready, sleeping 2s..."
+            sleep 2
+          done
+
+          echo "❌ /health never returned 200 within 30s"
+          echo "=== Container logs ==="
+          docker logs mcp-test
+          exit 1
+
+      - name: Cleanup container
+        if: always()
+        run: docker rm -f mcp-test || true

--- a/mcp_server/infra/lambda/openid-config/openid-config.mjs
+++ b/mcp_server/infra/lambda/openid-config/openid-config.mjs
@@ -105,6 +105,14 @@ async function getOpenIDConfiguration() {
     const enhancedConfig = {
       ...cognitoConfig,
       registration_endpoint: registrationEndpointUrl,
+      grant_types_supported: [
+        ...(cognitoConfig.grant_types_supported || []),
+        "authorization_code"
+      ],
+      token_endpoint_auth_methods_supported: [
+        ...(cognitoConfig.token_endpoint_auth_methods_supported || []),
+        "none"
+      ],
       code_challenge_methods_supported: ["S256"]
     };
 

--- a/mcp_server/src/package.json
+++ b/mcp_server/src/package.json
@@ -21,7 +21,7 @@
     "typescript": "^5.8.3"
   },
   "scripts": {
-    "build": "tsc && cp *.js *.json dist/ && cp -r prompts mcp auth dist/",
+    "build": "tsc && cp *.js *.json dist/ && cp -r prompts mcp auth dist/ && mkdir -p dist/tools dist/resources && cp tools/*.js dist/tools/ && cp resources/*.js dist/resources/",
     "start": "npx tsx --env-file=.env --watch index.js",
     "start:prod": "node dist/index.js",
     "test": "vitest run",


### PR DESCRIPTION
Three related CI/fix changes, bundled so the new smoke-test job has something that actually works to test against.

**1. `docker-smoke-test` job.** Builds the container, runs it with dummy env, probes `/health`. Catches the class of bug that broke yesterday's deploy (missing file in `dist/`, wrong `COPY`, broken `CMD`, missing runtime dep) in ~60s before merge. Uses [Docker's "test before push" pattern](https://docs.docker.com/build/ci/github-actions/test-before-push/) (`setup-buildx-action` + `build-push-action` with `load: true` and GHA layer cache).

**2. `merge_group` trigger.** Without this, the `Tests` workflow never runs against the synthetic merge commits the queue creates, so required checks never report, and PRs get evicted after `check_response_timeout_minutes` (60). PR #50 shows the exact pattern: added to queue 15:52Z today, evicted 17:19Z. Adding `merge_group:` fixes merge-queue compatibility for all jobs in the workflow.

**3. Bundled build + OAuth fixes from #58.** The smoke-test job would fail on `main` today because the current build script drops `tools/register.js` and `resources/register.js` from `dist/`. Included here so this PR is self-contained and doesn't have a hidden dependency on #58. If #58 merges first, these commits become no-ops during merge. If this PR merges first, #58 becomes empty and can be closed.

Verified locally: clean build, image starts, `/health` responds in ~6s with the fixes; container exits (1) with `ERR_MODULE_NOT_FOUND` without them.