### PR TITLE
chore(deps): group aws-cdk CLI with aws-cdk-lib in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # CDK infrastructure package. Group aws-cdk (CLI) and aws-cdk-lib (library)
+  # so they are always bumped together. The CLI must support the cloud-assembly
+  # schema emitted by the library, otherwise `cdk synth` fails with a schema
+  # version mismatch.
+  - package-ecosystem: npm
+    directory: /mcp_server/infra
+    schedule:
+      interval: weekly
+    groups:
+      aws-cdk:
+        patterns:
+          - "aws-cdk"
+          - "aws-cdk-lib"
+
+  # MCP server application package.
+  - package-ecosystem: npm
+    directory: /mcp_server/src
+    schedule:
+      interval: weekly
+
+  # GitHub Actions workflows.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` that groups `aws-cdk` (CLI) and `aws-cdk-lib` (library) for the `/mcp_server/infra` package so they are always bumped together.

## Why
PR #83 (security bump of `aws-cdk-lib` 2.245.0 → 2.260.0) broke the `cdk-synth` CI job:

```
Cloud assembly schema version mismatch: Maximum schema version supported is 53.x.x,
but found 54.0.0. You need at least CLI version 2.1128.0 to read this manifest.
```

`aws-cdk-lib` 2.260.0 emits cloud-assembly schema v54, but the `aws-cdk` CLI was independently pinned at `^2.1115.0` (schema ≤53). Because the CLI had no security advisory, the security-update PR never touched it. Grouping keeps the two in lockstep for future version-update PRs so this mismatch can't recur.

Also enables weekly version updates for `/mcp_server/src` and GitHub Actions.

## Testing
- Validated YAML structure.
- Verified the fix locally (CLI `^2.1128.0` + `aws-cdk-lib` 2.260.0): `cdk synth`, `npm run lint`, `npm run typecheck` all pass. That CLI bump is applied directly on PR #83.

## Note
This config must merge to the default branch for Dependabot to use it.